### PR TITLE
Add prebuilt binaries and install script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+# .github/workflows/release.yaml
+name: Release
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  releases-matrix:
+    name: Release Go Binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64, arm64]
+        exclude:
+          - goarch: "386"
+            goos: darwin
+          - goarch: arm64
+            goos: windows
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wangyoucao577/go-release-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goos: ${{ matrix.goos }}
+          goarch: ${{ matrix.goarch }}
+          goversion: "https://dl.google.com/go/go1.20.6.linux-amd64.tar.gz"
+          extra_files: LICENSE README.md
+          project_path: cmd/deployx
+          overwrite: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,5 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: "https://dl.google.com/go/go1.20.6.linux-amd64.tar.gz"
-          extra_files: LICENSE README.md
           project_path: cmd/deployx
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ with [compose-spec](https://github.com/compose-spec/compose-spec).
 Interactive install script:
 
 ```bash
-bash <(curl https://raw.githubusercontent.com/Rei-x/deployx/main/install.sh)
+bash <(curl https://raw.githubusercontent.com/aaraney/deployx/main/install.sh)
 ```
 
 Or non-interactive install as docker-plugin (requires sudo):
 
 ```bash
-curl -sL https://raw.githubusercontent.com/rei-x/deployx/main/install.sh | bash -s -- -y
+curl -sL https://raw.githubusercontent.com/aaraney/deployx/main/install.sh | bash -s -- -y
 ```
 
 Or non-interactive install just as a binary (./deployx):
 
 ```bash
-curl -sL https://raw.githubusercontent.com/rei-x/deployx/main/install.sh | bash -s -- -n
+curl -sL https://raw.githubusercontent.com/aaraney/deployx/main/install.sh | bash -s -- -n
 ```
 
 ### Building from source

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ with [compose-spec](https://github.com/compose-spec/compose-spec).
 
 ## Installing
 
+### Prebuilt binaries
+
+Interactive install script:
+
+```bash
+bash <(curl https://raw.githubusercontent.com/Rei-x/deployx/main/install.sh)
+```
+
+Or non-interactive install as docker-plugin (requires sudo):
+
+```bash
+curl -sL https://raw.githubusercontent.com/rei-x/deployx/main/install.sh | bash -s -- -y
+```
+
+Or non-interactive install just as a binary (./deployx):
+
+```bash
+curl -sL https://raw.githubusercontent.com/rei-x/deployx/main/install.sh | bash -s -- -n
+```
+
 ### Building from source
 
 Building from source requires go and make be installed. Install go using either your package manager

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ while getopts ":yn" opt; do
   esac
 done
 
-url="https://api.github.com/repos/rei-x/deployx/releases/latest"
+url="https://api.github.com/repos/aaraney/deployx/releases/latest"
 
 os=$(uname -s)
 arch=$(uname -m)

--- a/install.sh
+++ b/install.sh
@@ -94,7 +94,7 @@ if [ "$install_as_plugin" = "y" ]; then
 
   sudo mkdir -p $install_path
 
-  mv deployx $install_path
+  sudo mv deployx $install_path
 
   echo "You can now use docker deployx"
 else

--- a/install.sh
+++ b/install.sh
@@ -88,13 +88,24 @@ if [ "$install_without_plugin" = true ]; then
 fi
 
 if [ "$install_as_plugin" = "y" ]; then
-  install_path=$HOME/.docker/cli-plugins
+  install_path="${HOME}"/.docker/cli-plugins
 
   echo "Installing deployx to $install_path"
 
-  sudo mkdir -p $install_path
+  mkdir -p "${install_path}" 2>/dev/null || sudo mkdir -p "${install_path}"
 
-  sudo mv deployx $install_path
+  if [ $? -ne 0 ]; then
+    echo "Failed to create directory $install_path"
+    exit 1
+  fi
+
+  # move deployx to installation path
+  mv deployx "${install_path}"/docker-deployx 2>/dev/null || sudo mv deployx "${install_path}"/docker-deployx
+
+  if [ $? -ne 0 ]; then
+    echo "Failed to move deployx to $install_path"
+    exit 1
+  fi
 
   echo "You can now use docker deployx"
 else

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+install_with_plugin=false
+install_without_plugin=false
+
+while getopts ":yn" opt; do
+  case $opt in
+  n)
+    install_without_plugin=true
+    ;;
+  y)
+    install_with_plugin=true
+    ;;
+  \?)
+    echo "Invalid option: -$OPTARG" >&2
+    ;;
+  esac
+done
+
+url="https://api.github.com/repos/rei-x/deployx/releases/latest"
+
+os=$(uname -s)
+arch=$(uname -m)
+
+if [ "$arch" = "x86_64" ]; then
+  arch="amd64"
+elif [ "$arch" = "aarch64" ]; then
+  arch="arm64"
+elif [ "$arch" = "armv7l" ]; then
+  arch="arm"
+elif [ "$arch" = "armv6l" ]; then
+  arch="arm"
+elif [ "$arch" = "armv5l" ]; then
+  arch="arm"
+elif [ "$arch" = "i386" ]; then
+  arch="386"
+else
+  echo "Unsupported architecture: $arch"
+  exit 1
+fi
+
+if [ "$os" = "Linux" ]; then
+  os="linux"
+elif [ "$os" = "Darwin" ]; then
+  os="darwin"
+elif [ "$os" = "Windows" ]; then
+  os="windows"
+else
+  echo "Unsupported OS: $os"
+  exit 1
+fi
+
+echo "Downloading deployx binary for $os $arch"
+
+curl --progress-bar --show-error -sL $url | grep "browser_download_url.*deployx.*$os.*$arch" | cut -d '"' -f 4 | wget -qi -
+
+# check md5sum
+
+echo "Checking md5sum of file"
+
+md5sum=$(md5sum deployx*.tar.gz | cut -d ' ' -f 1)
+md5sum_file=$(cat deployx*.tar.gz.md5 | cut -d ' ' -f 1)
+
+if [ "$md5sum" != "$md5sum_file" ]; then
+  echo "md5sum does not match"
+  exit 1
+fi
+
+echo "MD5sum matches"
+
+tar -xzf deployx*.tar.gz
+
+# ask if user wants to install as docker plugin
+
+if [ "$install_with_plugin" = false ] && [ "$install_without_plugin" = false ]; then
+  echo "Do you want to install deployx as a docker plugin? (y/n)"
+  read install_as_plugin
+else
+  install_as_plugin="y"
+fi
+
+if [ "$install_with_plugin" = true ]; then
+  install_as_plugin="y"
+fi
+
+if [ "$install_without_plugin" = true ]; then
+  install_as_plugin="n"
+fi
+
+if [ "$install_as_plugin" = "y" ]; then
+  install_path=$HOME/.docker/cli-plugins
+
+  echo "Installing deployx to $install_path"
+
+  sudo mkdir -p $install_path
+
+  mv deployx $install_path
+
+  echo "You can now use docker deployx"
+else
+  echo "You can now use ./deployx"
+fi
+
+# clean
+
+rm deployx*.tar.gz*


### PR DESCRIPTION
I'm using this plugin in my deployment and so far I love this!

The issue I'm having is that building it from source takes about 1 minute, so I created easy install script.

I don't know if you want something like this in your repo, it's just a proposal, I can continue to use my fork for this.

(if you want to merge it, you need to edit repo url)